### PR TITLE
Fix pinned tabs bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "marble",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "marble",
-      "version": "1.2.1",
+      "version": "1.2.2",
       "license": "GPL-3.0",
       "devDependencies": {
         "colors": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "marble",
   "productName": "Marble",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "author": "Sylvester Wilmott",
   "license": "GPL-3.0",
   "devDependencies": {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "__MSG_EXT_NAME__",
   "description": "__MSG_EXT_DESCRIPTION__",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "manifest_version": 3,
    "minimum_chrome_version": "89",
   "default_locale": "en",


### PR DESCRIPTION
Fixes #28 

1. While "Ignore Pinned Tabs" setting is enabled, pinned tabs always stay pinned.
2. When creating multiple tabs from a pinned tab, new tabs are grouped but the parent tab remains pinned.